### PR TITLE
Stop trying to get identical boost factors between py and cpp

### DIFF
--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1499,29 +1499,26 @@ class SpatialPooler(object):
     @return list with indices of the winning columns
     """
 
-    # When a column is selected, add a small number to its overlap. If it was
-    # tied with other not-yet-processed columns, those columns will now lose the
-    # tie-breaker when they're processed.
-    addToWinners = max(overlaps) / 1000.0
-    if addToWinners == 0:
-      addToWinners = 0.001
-    tieBrokenOverlaps = numpy.array(overlaps, dtype=realDType)
-
-    winners = []
+    activeArray = numpy.zeros(self._numColumns, dtype="bool")
 
     for column, overlap in enumerate(overlaps):
       if overlap >= self._stimulusThreshold:
         neighborhood = self._getColumnNeighborhood(column)
-        neighborhoodOverlaps = tieBrokenOverlaps[neighborhood]
+        neighborhoodOverlaps = overlaps[neighborhood]
 
         numBigger = numpy.count_nonzero(neighborhoodOverlaps > overlap)
 
-        numActive = int(0.5 + density * len(neighborhood))
-        if numBigger < numActive:
-          winners.append(column)
-          tieBrokenOverlaps[column] += addToWinners
+        # When there is a tie, favor neighbors that are already selected as
+        # active.
+        ties = numpy.where(neighborhoodOverlaps == overlap)
+        tiedNeighbors = neighborhood[ties]
+        numTiesLost = numpy.count_nonzero(activeArray[tiedNeighbors])
 
-    return numpy.array(winners, dtype=uintType)
+        numActive = int(0.5 + density * len(neighborhood))
+        if numBigger + numTiesLost < numActive:
+          activeArray[column] = True
+
+    return activeArray.nonzero()[0]
 
 
   def _isUpdateRound(self):

--- a/src/nupic/research/spatial_pooler.py
+++ b/src/nupic/research/spatial_pooler.py
@@ -1352,11 +1352,9 @@ class SpatialPooler(object):
       targetDensity = float(self._numActiveColumnsPerInhArea) / inhibitionArea
       targetDensity = min(targetDensity, 0.5)
 
-    boostFactors = numpy.exp(
+    self._boostFactors = numpy.exp(
       (targetDensity - self._activeDutyCycles) * self._maxBoost)
 
-    # Avoid floating point mismatches between implementations.
-    self._boostFactors = numpy.round(boostFactors, decimals=2)
 
 
   def _updateBoostFactorsLocal(self):
@@ -1371,11 +1369,8 @@ class SpatialPooler(object):
       maskNeighbors = self._getColumnNeighborhood(i)
       targetDensity[i] = numpy.mean(self._activeDutyCycles[maskNeighbors])
 
-    boostFactors = numpy.exp(
+    self._boostFactors = numpy.exp(
       (targetDensity - self._activeDutyCycles) * self._maxBoost)
-
-    # Avoid floating point mismatches between implementations.
-    self._boostFactors = numpy.round(boostFactors, decimals=2)
 
 
   def _updateBookeepingVars(self, learn):

--- a/tests/unit/nupic/research/spatial_pooler_compatability_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_compatability_test.py
@@ -38,7 +38,7 @@ numRecords = 100
 
 
 
-class SpatialPoolerCompatabilityTest(unittest.TestCase):
+class SpatialPoolerCompatibilityTest(unittest.TestCase):
   """
   Tests to ensure that the PY and CPP implementations of the spatial pooler
   are functionally identical.
@@ -47,7 +47,8 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
   def setUp(self):
     # Set to 1 for more verbose debugging output
     self.verbosity = 1
-    
+
+
   def assertListAlmostEqual(self, alist, blist):
     self.assertEqual(len(alist), len(blist))
     for a, b in zip(alist, blist):
@@ -168,10 +169,10 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
     Run the PY and CPP implementations side by side on random inputs.
     If seed is None a random seed will be chosen based on time, otherwise
     the fixed seed will be used.
-    
+
     If learnMode is None learning will be randomly turned on and off.
     If it is False or True then set it accordingly.
-    
+
     If convertEveryIteration is True, the CPP will be copied from the PY
     instance on every iteration just before each compute.
     """
@@ -184,7 +185,7 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
     threshold = 0.8
     inputMatrix = (
       randomState.rand(numRecords,numInputs) > threshold).astype(uintType)
-    
+
     # Run side by side for numRecords iterations
     for i in xrange(numRecords):
       if learnMode is None:
@@ -196,11 +197,18 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
       PyActiveArray = numpy.zeros(numColumns).astype(uintType)
       CppActiveArray = numpy.zeros(numColumns).astype(uintType)
       inputVector = inputMatrix[i,:]
-      
+
       pySp.compute(inputVector, learn, PyActiveArray)
       cppSp.compute(inputVector, learn, CppActiveArray)
       self.assertListEqual(list(PyActiveArray), list(CppActiveArray))
       self.compare(pySp,cppSp)
+
+      # The boost factors were similar enough to get this far.
+      # Now make them completely equal so that small variations don't cause
+      # columns to have slightly higher boosted overlaps.
+      cppBoostFactors = numpy.zeros(numColumns, dtype=realType)
+      cppSp.getBoostFactors(cppBoostFactors)
+      pySp.setBoostFactors(cppBoostFactors)
 
       # The permanence values for the two implementations drift ever so slowly
       # over time due to numerical precision issues. This occasionally causes
@@ -237,7 +245,7 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
       self.assertListEqual(list(activeArray1), list(activeArray2))
 
 
-  def testCompatability1(self):
+  def testCompatibility1(self):
     params = {
       "inputDimensions": [4,4],
       "columnDimensions": [5,3],
@@ -267,7 +275,8 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
 
     self.runSideBySide(params)
 
-  def testCompatabilityNoLearn(self):
+
+  def testCompatibilityNoLearn(self):
     params = {
       "inputDimensions": [4,4],
       "columnDimensions": [5,3],
@@ -290,7 +299,7 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
     self.runSideBySide(params, seed = None, learnMode = False)
 
 
-  def testCompatability2(self):
+  def testCompatibility2(self):
     params = {
       "inputDimensions": [12,7],
       "columnDimensions": [4,15],
@@ -313,7 +322,7 @@ class SpatialPoolerCompatabilityTest(unittest.TestCase):
     self.runSideBySide(params, convertEveryIteration = True)
 
 
-  def testCompatability3(self):
+  def testCompatibility3(self):
     params = {
       "inputDimensions": [2,4,5],
       "columnDimensions": [4,3,3],

--- a/tests/unit/nupic/research/spatial_pooler_unit_test.py
+++ b/tests/unit/nupic/research/spatial_pooler_unit_test.py
@@ -621,8 +621,8 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._activeDutyCycles = numpy.array([0.1, 0.1, 0.1, 0.1, 0.1, 0.1])
     sp._boostFactors = numpy.zeros(sp._numColumns)
     sp._updateBoostFactors()
-    self.assertListEqual(list(sp._boostFactors),
-                         [1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+    numpy.testing.assert_almost_equal(
+      sp._boostFactors, [1.0, 1.0, 1.0, 1.0, 1.0, 1.0])
 
     sp._maxBoost = 10.0
     sp._numColumns = 6
@@ -632,15 +632,17 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._wrapAround = True
     sp._activeDutyCycles = numpy.array([0.1, 0.3, 0.02, 0.04, 0.7, 0.12])
     sp._updateBoostFactors()
-    self.assertListEqual(list(sp._boostFactors),
-                         [3.11, 0.42, 6.91, 5.66, 0.01, 2.54])
+    numpy.testing.assert_almost_equal(
+      sp._boostFactors,
+      [3.1059927, 0.4203504, 6.912514, 5.6594878, 0.007699, 2.5429718])
 
     sp._maxBoost = 2.0
     sp._numColumns = 6
     sp._activeDutyCycles = numpy.array([0.1, 0.3, 0.02, 0.04, 0.7, 0.12])
     sp._updateBoostFactors()
-    self.assertListEqual(list(sp._boostFactors),
-                         [1.25, 0.84, 1.47, 1.41, 0.38, 1.21])
+    numpy.testing.assert_almost_equal(
+      sp._boostFactors,
+      [1.2544117, 0.8408573, 1.4720657, 1.4143452, 0.3778215, 1.2052255])
 
     sp._globalInhibition = True
     sp._maxBoost = 10.0
@@ -649,8 +651,10 @@ class SpatialPoolerTest(unittest.TestCase):
     sp._inhibitionRadius = 3
     sp._activeDutyCycles = numpy.array([0.1, 0.3, 0.02, 0.04, 0.7, 0.12])
     sp._updateBoostFactors()
-    self.assertListEqual(list(sp._boostFactors),
-                         [1.95, 0.26, 4.33, 3.55, 0.00, 1.59])
+
+    numpy.testing.assert_almost_equal(
+      sp._boostFactors,
+      [1.947734, 0.2635971, 4.3347618, 3.5490028, 0.0048279, 1.5946698])
 
 
   def testUpdateInhibitionRadius(self):


### PR DESCRIPTION
This requires a matching change in the C++ that gets rid of the rounding: https://github.com/numenta/nupic.core/pull/1176

It fixes an additional compatibility issue in inhibitColumnsLocal_ to match the change https://github.com/numenta/nupic.core/commit/8c93df94f6848a856cd84df6c6bbf2d11fa7dfec